### PR TITLE
allow bundling addon

### DIFF
--- a/src/addon.json
+++ b/src/addon.json
@@ -3,7 +3,7 @@
   "type": "plugin",
   "name": "3D object",
   "id": "Mikal_3DObject",
-  "version": "2.73.0",
+  "version": "2.73.1",
   "author": "Mikal",
   "website": "https://www.construct.net",
   "documentation": "https://www.construct.net",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -24,7 +24,7 @@
       this._info.SetHasImage(true)
       this._info.SetSupportsEffects(true) // allow effects
       this._info.SetMustPreDraw(false)
-      this._info.SetCanBeBundled(false)
+      this._info.SetCanBeBundled(true)
       this._info.SetIs3D(true)
       this._info.SetSupportsColor(true)
       this._info.AddCommonPositionACEs()


### PR DESCRIPTION
Hey Mikal,
I'd love if the addon was allowed to be bundled, for the particular reasons: In team work it's really annoying and tedious to always tell all team members to double check and make sure they update their 3dObject addon and it can lead to issue like a team member setting a build live with an out of date 3dobject addon with a potentially severe bug.

In case the disable of bundling was done as it was a paid addon before, this shouldn't be a concern anymore. But if there are other important reasons I guess I'll have to live with it or maybe I'll do the change for each release locally.